### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/.venv/Lib/site-packages/autogen-0.8.7.dist-info/METADATA
+++ b/.venv/Lib/site-packages/autogen-0.8.7.dist-info/METADATA
@@ -1,7 +1,7 @@
 Metadata-Version: 2.1
 Name: autogen
 Version: 0.8.7
-Summary: Alias package for pyautogen
+Summary: Alias package for ag2
 Home-page: https://github.com/ag2ai/ag2
 Author: Chi Wang & Qingyun Wu
 Author-email: support@ag2.ai
@@ -14,117 +14,117 @@ Requires-Python: >=3.9,<3.14
 Description-Content-Type: text/markdown
 License-File: LICENSE
 License-File: NOTICE.md
-Requires-Dist: pyautogen==0.8.7
+Requires-Dist: ag2==0.8.7
 Provides-Extra: anthropic
-Requires-Dist: pyautogen[anthropic]==0.8.7; extra == "anthropic"
+Requires-Dist: ag2[anthropic]==0.8.7; extra == "anthropic"
 Provides-Extra: autobuild
-Requires-Dist: pyautogen[autobuild]==0.8.7; extra == "autobuild"
+Requires-Dist: ag2[autobuild]==0.8.7; extra == "autobuild"
 Provides-Extra: bedrock
-Requires-Dist: pyautogen[bedrock]==0.8.7; extra == "bedrock"
+Requires-Dist: ag2[bedrock]==0.8.7; extra == "bedrock"
 Provides-Extra: blendsearch
-Requires-Dist: pyautogen[blendsearch]==0.8.7; extra == "blendsearch"
+Requires-Dist: ag2[blendsearch]==0.8.7; extra == "blendsearch"
 Provides-Extra: browser-use
-Requires-Dist: pyautogen[browser-use]==0.8.7; extra == "browser-use"
+Requires-Dist: ag2[browser-use]==0.8.7; extra == "browser-use"
 Provides-Extra: captainagent
-Requires-Dist: pyautogen[captainagent]==0.8.7; extra == "captainagent"
+Requires-Dist: ag2[captainagent]==0.8.7; extra == "captainagent"
 Provides-Extra: cerebras
-Requires-Dist: pyautogen[cerebras]==0.8.7; extra == "cerebras"
+Requires-Dist: ag2[cerebras]==0.8.7; extra == "cerebras"
 Provides-Extra: cohere
-Requires-Dist: pyautogen[cohere]==0.8.7; extra == "cohere"
+Requires-Dist: ag2[cohere]==0.8.7; extra == "cohere"
 Provides-Extra: commsagent-discord
-Requires-Dist: pyautogen[commsagent-discord]==0.8.7; extra == "commsagent-discord"
+Requires-Dist: ag2[commsagent-discord]==0.8.7; extra == "commsagent-discord"
 Provides-Extra: commsagent-slack
-Requires-Dist: pyautogen[commsagent-slack]==0.8.7; extra == "commsagent-slack"
+Requires-Dist: ag2[commsagent-slack]==0.8.7; extra == "commsagent-slack"
 Provides-Extra: commsagent-telegram
-Requires-Dist: pyautogen[commsagent-telegram]==0.8.7; extra == "commsagent-telegram"
+Requires-Dist: ag2[commsagent-telegram]==0.8.7; extra == "commsagent-telegram"
 Provides-Extra: cosmosdb
-Requires-Dist: pyautogen[cosmosdb]==0.8.7; extra == "cosmosdb"
+Requires-Dist: ag2[cosmosdb]==0.8.7; extra == "cosmosdb"
 Provides-Extra: crawl4ai
-Requires-Dist: pyautogen[crawl4ai]==0.8.7; extra == "crawl4ai"
+Requires-Dist: ag2[crawl4ai]==0.8.7; extra == "crawl4ai"
 Provides-Extra: deepseek
-Requires-Dist: pyautogen[deepseek]==0.8.7; extra == "deepseek"
+Requires-Dist: ag2[deepseek]==0.8.7; extra == "deepseek"
 Provides-Extra: dev
-Requires-Dist: pyautogen[dev]==0.8.7; extra == "dev"
+Requires-Dist: ag2[dev]==0.8.7; extra == "dev"
 Provides-Extra: docs
-Requires-Dist: pyautogen[docs]==0.8.7; extra == "docs"
+Requires-Dist: ag2[docs]==0.8.7; extra == "docs"
 Provides-Extra: flaml
-Requires-Dist: pyautogen[flaml]==0.8.7; extra == "flaml"
+Requires-Dist: ag2[flaml]==0.8.7; extra == "flaml"
 Provides-Extra: gemini
-Requires-Dist: pyautogen[gemini]==0.8.7; extra == "gemini"
+Requires-Dist: ag2[gemini]==0.8.7; extra == "gemini"
 Provides-Extra: gemini-realtime
-Requires-Dist: pyautogen[gemini-realtime]==0.8.7; extra == "gemini-realtime"
+Requires-Dist: ag2[gemini-realtime]==0.8.7; extra == "gemini-realtime"
 Provides-Extra: google-api
-Requires-Dist: pyautogen[google-api]==0.8.7; extra == "google-api"
+Requires-Dist: ag2[google-api]==0.8.7; extra == "google-api"
 Provides-Extra: google-client
-Requires-Dist: pyautogen[google-client]==0.8.7; extra == "google-client"
+Requires-Dist: ag2[google-client]==0.8.7; extra == "google-client"
 Provides-Extra: google-search
-Requires-Dist: pyautogen[google-search]==0.8.7; extra == "google-search"
+Requires-Dist: ag2[google-search]==0.8.7; extra == "google-search"
 Provides-Extra: graph
-Requires-Dist: pyautogen[graph]==0.8.7; extra == "graph"
+Requires-Dist: ag2[graph]==0.8.7; extra == "graph"
 Provides-Extra: graph-rag-falkor-db
-Requires-Dist: pyautogen[graph-rag-falkor-db]==0.8.7; extra == "graph-rag-falkor-db"
+Requires-Dist: ag2[graph-rag-falkor-db]==0.8.7; extra == "graph-rag-falkor-db"
 Provides-Extra: groq
-Requires-Dist: pyautogen[groq]==0.8.7; extra == "groq"
+Requires-Dist: ag2[groq]==0.8.7; extra == "groq"
 Provides-Extra: interop
-Requires-Dist: pyautogen[interop]==0.8.7; extra == "interop"
+Requires-Dist: ag2[interop]==0.8.7; extra == "interop"
 Provides-Extra: interop-crewai
-Requires-Dist: pyautogen[interop-crewai]==0.8.7; extra == "interop-crewai"
+Requires-Dist: ag2[interop-crewai]==0.8.7; extra == "interop-crewai"
 Provides-Extra: interop-langchain
-Requires-Dist: pyautogen[interop-langchain]==0.8.7; extra == "interop-langchain"
+Requires-Dist: ag2[interop-langchain]==0.8.7; extra == "interop-langchain"
 Provides-Extra: interop-pydantic-ai
-Requires-Dist: pyautogen[interop-pydantic-ai]==0.8.7; extra == "interop-pydantic-ai"
+Requires-Dist: ag2[interop-pydantic-ai]==0.8.7; extra == "interop-pydantic-ai"
 Provides-Extra: jupyter-executor
-Requires-Dist: pyautogen[jupyter-executor]==0.8.7; extra == "jupyter-executor"
+Requires-Dist: ag2[jupyter-executor]==0.8.7; extra == "jupyter-executor"
 Provides-Extra: lint
-Requires-Dist: pyautogen[lint]==0.8.7; extra == "lint"
+Requires-Dist: ag2[lint]==0.8.7; extra == "lint"
 Provides-Extra: lmm
-Requires-Dist: pyautogen[lmm]==0.8.7; extra == "lmm"
+Requires-Dist: ag2[lmm]==0.8.7; extra == "lmm"
 Provides-Extra: long-context
-Requires-Dist: pyautogen[long-context]==0.8.7; extra == "long-context"
+Requires-Dist: ag2[long-context]==0.8.7; extra == "long-context"
 Provides-Extra: mathchat
-Requires-Dist: pyautogen[mathchat]==0.8.7; extra == "mathchat"
+Requires-Dist: ag2[mathchat]==0.8.7; extra == "mathchat"
 Provides-Extra: mcp
-Requires-Dist: pyautogen[mcp]==0.8.7; extra == "mcp"
+Requires-Dist: ag2[mcp]==0.8.7; extra == "mcp"
 Provides-Extra: mistral
-Requires-Dist: pyautogen[mistral]==0.8.7; extra == "mistral"
+Requires-Dist: ag2[mistral]==0.8.7; extra == "mistral"
 Provides-Extra: neo4j
-Requires-Dist: pyautogen[neo4j]==0.8.7; extra == "neo4j"
+Requires-Dist: ag2[neo4j]==0.8.7; extra == "neo4j"
 Provides-Extra: ollama
-Requires-Dist: pyautogen[ollama]==0.8.7; extra == "ollama"
+Requires-Dist: ag2[ollama]==0.8.7; extra == "ollama"
 Provides-Extra: openai
-Requires-Dist: pyautogen[openai]==0.8.7; extra == "openai"
+Requires-Dist: ag2[openai]==0.8.7; extra == "openai"
 Provides-Extra: openai-realtime
-Requires-Dist: pyautogen[openai-realtime]==0.8.7; extra == "openai-realtime"
+Requires-Dist: ag2[openai-realtime]==0.8.7; extra == "openai-realtime"
 Provides-Extra: rag
-Requires-Dist: pyautogen[rag]==0.8.7; extra == "rag"
+Requires-Dist: ag2[rag]==0.8.7; extra == "rag"
 Provides-Extra: redis
-Requires-Dist: pyautogen[redis]==0.8.7; extra == "redis"
+Requires-Dist: ag2[redis]==0.8.7; extra == "redis"
 Provides-Extra: retrievechat
-Requires-Dist: pyautogen[retrievechat]==0.8.7; extra == "retrievechat"
+Requires-Dist: ag2[retrievechat]==0.8.7; extra == "retrievechat"
 Provides-Extra: retrievechat-couchbase
-Requires-Dist: pyautogen[retrievechat-couchbase]==0.8.7; extra == "retrievechat-couchbase"
+Requires-Dist: ag2[retrievechat-couchbase]==0.8.7; extra == "retrievechat-couchbase"
 Provides-Extra: retrievechat-mongodb
-Requires-Dist: pyautogen[retrievechat-mongodb]==0.8.7; extra == "retrievechat-mongodb"
+Requires-Dist: ag2[retrievechat-mongodb]==0.8.7; extra == "retrievechat-mongodb"
 Provides-Extra: retrievechat-pgvector
-Requires-Dist: pyautogen[retrievechat-pgvector]==0.8.7; extra == "retrievechat-pgvector"
+Requires-Dist: ag2[retrievechat-pgvector]==0.8.7; extra == "retrievechat-pgvector"
 Provides-Extra: retrievechat-qdrant
-Requires-Dist: pyautogen[retrievechat-qdrant]==0.8.7; extra == "retrievechat-qdrant"
+Requires-Dist: ag2[retrievechat-qdrant]==0.8.7; extra == "retrievechat-qdrant"
 Provides-Extra: teachable
-Requires-Dist: pyautogen[teachable]==0.8.7; extra == "teachable"
+Requires-Dist: ag2[teachable]==0.8.7; extra == "teachable"
 Provides-Extra: test
-Requires-Dist: pyautogen[test]==0.8.7; extra == "test"
+Requires-Dist: ag2[test]==0.8.7; extra == "test"
 Provides-Extra: together
-Requires-Dist: pyautogen[together]==0.8.7; extra == "together"
+Requires-Dist: ag2[together]==0.8.7; extra == "together"
 Provides-Extra: twilio
-Requires-Dist: pyautogen[twilio]==0.8.7; extra == "twilio"
+Requires-Dist: ag2[twilio]==0.8.7; extra == "twilio"
 Provides-Extra: types
-Requires-Dist: pyautogen[types]==0.8.7; extra == "types"
+Requires-Dist: ag2[types]==0.8.7; extra == "types"
 Provides-Extra: websockets
-Requires-Dist: pyautogen[websockets]==0.8.7; extra == "websockets"
+Requires-Dist: ag2[websockets]==0.8.7; extra == "websockets"
 Provides-Extra: websurfer
-Requires-Dist: pyautogen[websurfer]==0.8.7; extra == "websurfer"
+Requires-Dist: ag2[websurfer]==0.8.7; extra == "websurfer"
 Provides-Extra: wikipedia
-Requires-Dist: pyautogen[wikipedia]==0.8.7; extra == "wikipedia"
+Requires-Dist: ag2[wikipedia]==0.8.7; extra == "wikipedia"
 
 <a name="readme-top"></a>
 
@@ -133,7 +133,7 @@ Requires-Dist: pyautogen[wikipedia]==0.8.7; extra == "wikipedia"
   <img src="https://raw.githubusercontent.com/ag2ai/ag2/27b37494a6f72b1f8050f6bd7be9a7ff232cf749/website/static/img/ag2.svg" width="150" title="hover text">
   <br>
   <br>
-  <img src="https://img.shields.io/pypi/dm/pyautogen?label=PyPI%20downloads">
+  <img src="https://img.shields.io/pypi/dm/ag2?label=PyPI%20downloads">
   <a href="https://badge.fury.io/py/autogen"><img src="https://badge.fury.io/py/autogen.svg"></a>
   <a href="https://github.com/ag2ai/ag2/actions/workflows/python-package.yml">
     <img src="https://github.com/ag2ai/ag2/actions/workflows/python-package.yml/badge.svg">
@@ -193,7 +193,7 @@ For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](h
 
 ### Installation
 
-AG2 requires **Python version >= 3.9, < 3.14**. AG2 is available via `ag2` (or its alias `pyautogen` or `autogen`) on PyPI.
+AG2 requires **Python version >= 3.9, < 3.14**. AG2 is available via `ag2` (or its alias `ag2` or `autogen`) on PyPI.
 
 ```bash
 pip install ag2[openai]


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
